### PR TITLE
Avoid mediaUrl null reference in chat listing

### DIFF
--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -534,11 +534,11 @@ export class ChannelStartupService {
 
     const cleanedMessage = { ...message };
 
-    const mediaUrl = cleanedMessage.message.mediaUrl;
-
-    delete cleanedMessage.message.base64;
+    const mediaUrl = cleanedMessage.message?.mediaUrl;
 
     if (cleanedMessage.message) {
+      delete cleanedMessage.message.base64;
+
       // Limpa imageMessage
       if (cleanedMessage.message.imageMessage) {
         cleanedMessage.message.imageMessage = {
@@ -580,9 +580,8 @@ export class ChannelStartupService {
           name: cleanedMessage.message.documentWithCaptionMessage.name,
         };
       }
+      if (mediaUrl) cleanedMessage.message.mediaUrl = mediaUrl;
     }
-
-    if (mediaUrl) cleanedMessage.message.mediaUrl = mediaUrl;
 
     return cleanedMessage;
   }


### PR DESCRIPTION
## Summary
- guard cleanMessageData against null messages
- keep mediaUrl only when present

## Testing
- `npm run lint:check` *(fails: prettier formatting errors in whatsapp.baileys.service.ts)*
- `npm test` *(fails: cannot find module test/all.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a7244dced483318339e805999efa74